### PR TITLE
リノートできない問題を修正

### DIFF
--- a/src/features/note/NotePreview/NavRN.tsx
+++ b/src/features/note/NotePreview/NavRN.tsx
@@ -23,8 +23,7 @@ export default function NavRN({ note }: { note: entities.Note }) {
               className={menuItem}
               onClick={async () => {
                 if (!api) return
-                // 動かん(笑)
-                await api.request("notes/renotes", { noteId: note.id })
+                await api.request("notes/create", { renoteId: note.id })
               }}>
               <Repeat2 size={16} />
               RN


### PR DESCRIPTION
`notes/renotes`は対象ノートのRN一覧を取得するものであってRNするものではない