### PR TITLE
Fix cannot read property of undefined

### DIFF
--- a/src/features/api/clients/misskey-v12.ts
+++ b/src/features/api/clients/misskey-v12.ts
@@ -3,6 +3,12 @@ import MisskeyLatestClient from "./misskey-latest"
 export default class MisskeyV12Client extends MisskeyLatestClient {
   override async fetchEmojiUrl(name: string): Promise<string | null> {
     const { emojis } = await super.post("meta")
-    return emojis.find((e: any) => e.name == name)?.url ?? null
+    if (!emojis || !Object.keys(emojis).includes("find")) return null
+    return (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      emojis.find((e: any) => {
+        Object.keys(e).includes("name") && e.name == name
+      })?.url ?? null
+    )
   }
 }


### PR DESCRIPTION
`await super.post("meta")`がたまに`undefined`を返すらしく、`emojies.find`で`Cannot read propaties of undefined`を起こして死ぬので修正