### PR TITLE
api cacheの導入で生じた型エラーを修正

### DIFF
--- a/src/features/api/clients/base.ts
+++ b/src/features/api/clients/base.ts
@@ -52,7 +52,7 @@ export default class BaseClient {
    * @param opts - fetchのオプション
    * @memberof BaseClient
    */
-  async get<T>(path: string, props: GetProps, volatile?: boolean) {
+  async get<T>(path: string, props: GetProps = {}, volatile?: boolean) {
     const key = "g" + path + JSON.stringify(props)
 
     let cacheValid = key in this.cache
@@ -72,7 +72,7 @@ export default class BaseClient {
 
     if (!cacheValid) {
       this.cache[key] = {
-        res: this.realGet(path, props),
+        res: this.realGet<T>(path, props),
         issue: Date.now(),
         lifespan: props.lifespan,
       }
@@ -83,7 +83,7 @@ export default class BaseClient {
   private async realGet<T>(path: string, { opts }: GetProps) {
     const res = await fetch(this.host + "/api/" + path, opts)
     if (!res.ok) return null
-    return res.json()
+    return res.json() as Promise<T>
   }
 
   /**
@@ -93,7 +93,7 @@ export default class BaseClient {
    * @param opts - fetchのオプション
    * @memberof BaseClient
    */
-  async post<T>(path: string, props: PostProps, volatile?: boolean) {
+  async post<T>(path: string, props: PostProps = {}, volatile?: boolean) {
     const key = "p" + path + JSON.stringify(props)
 
     let cacheValid = key in this.cache
@@ -132,6 +132,6 @@ export default class BaseClient {
       ...opts,
     })
     if (!res.ok) return null
-    return res.json()
+    return res.json() as Promise<T>
   }
 }

--- a/src/features/api/clients/misskey-v12.ts
+++ b/src/features/api/clients/misskey-v12.ts
@@ -1,4 +1,4 @@
-import { Emoji } from ".."
+import { Emoji } from "../types"
 import MisskeyLatestClient from "./misskey-latest"
 
 export default class MisskeyV12Client extends MisskeyLatestClient {

--- a/src/features/api/clients/misskey-v13.ts
+++ b/src/features/api/clients/misskey-v13.ts
@@ -1,4 +1,4 @@
-import { Emoji } from ".."
+import { Emoji } from "../types"
 import MisskeyLatestClient from "./misskey-latest"
 
 export default class MisskeyV13Client extends MisskeyLatestClient {

--- a/src/features/timeline/TLSwitch.tsx
+++ b/src/features/timeline/TLSwitch.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode } from "react"
 import { useTLName } from "."
-import { TLChanNames } from "../api"
+import { TLChanNames } from "../api/types"
 
 const TLButton = ({ tl, children }: { tl: TLChanNames; children: ReactNode }) => {
   const [currentTl, setCurrentTl] = useTLName()

--- a/src/features/timeline/index.ts
+++ b/src/features/timeline/index.ts
@@ -3,8 +3,9 @@ import { atomWithStorage } from "jotai/utils"
 import { entities } from "misskey-js"
 import { useCallback, useEffect, useState } from "react"
 
-import { TLChanNameToAPIEndpoint, TLChanNames, useMisskeyJS, useStream } from "~/features/api"
+import { useMisskeyJS, useStream } from "~/features/api"
 import { useLogin } from "~/features/auth"
+import { TLChanNameToAPIEndpoint, TLChanNames } from "../api/types"
 
 ////////////////////////////////////////////////////////////////
 //  atoms


### PR DESCRIPTION
BaseClientとファイルの整理で生じた型エラーの暫定的な修正

getとpostのpropsを{}にした件については再考の余地アリ